### PR TITLE
Update the darwin setting file

### DIFF
--- a/examples/proteus.darwin.yaml
+++ b/examples/proteus.darwin.yaml
@@ -31,7 +31,7 @@ packages:
     use: openblas-lapack
   daetk:
   mpi:
-    use: mpich
+    use: host-mpi
   mpi4py:
   nose:
   coverage:

--- a/examples/proteus.darwin.yaml
+++ b/examples/proteus.darwin.yaml
@@ -20,7 +20,6 @@ packages:
   openjpeg: #dependency of chrono
     version: '2.1'
   openssl:
-    use: host-openssl
   python:
     host: false
     link: shared
@@ -32,18 +31,19 @@ packages:
     use: openblas-lapack
   daetk:
   mpi:
-    use: host-mpi
+    use: mpich
   mpi4py:
   nose:
   coverage:
   hdf5:
   petsc:
     version: 3.7.6
+    fortran: false
     openblas: true
     build_with: |
       parmetis, cmake, blas
     download: |
-      superlu, superlu_dist, hypre, blacs, scalapack, mumps
+      superlu, superlu_dist, hypre, blacs
     coptflags: -O2
     link: shared
     debug: false
@@ -59,7 +59,7 @@ packages:
     address_model: 64
     build_with: |
       python
-  scipy:
+#  scipy:
   h5py:
   pip:
   chrono:

--- a/examples/proteus.darwin.yaml
+++ b/examples/proteus.darwin.yaml
@@ -5,11 +5,8 @@
 # at the YAML files in the top-level directory and choose
 # the most *specific* file that matches your environment.
 
-parameters:
-  airgap: True
-
 extends:
-- file: osx_clt.yaml
+- file: homebrew.yaml
 
 
 # The packages list specifies all the packages that you
@@ -18,69 +15,116 @@ extends:
 # profile.
 
 packages:
-
-  launcher:
+  recordtype:
   cmake:
-  openjpeg:
+  openjpeg: #dependency of chrono
     version: '2.1'
+  openssl:
+    use: host-openssl
   python:
     host: false
     link: shared
     build_with: |
-
+      bzip2, sqlite, openssl
   blas:
-    use: host-osx-framework-accelerate
+    use: openblas
   lapack:
-    use: host-osx-framework-accelerate
+    use: openblas-lapack
   daetk:
   mpi:
-    use: openmpi
+    use: host-mpi
   mpi4py:
   nose:
+  coverage:
   hdf5:
-  pygments:
-  tornado:
-  pyzmq:
-  parmetis:
-  ipython:
-  matplotlib:
   petsc:
-    version: 3.7.5
+    version: 3.7.6
+    openblas: true
     build_with: |
-      parmetis, cmake, suitesparse
+      parmetis, cmake, blas
     download: |
-      superlu, superlu_dist
+      superlu, superlu_dist, hypre, blacs, scalapack, mumps
     coptflags: -O2
     link: shared
     debug: false
-    disable_fortran: true
   petsc4py:
     version: 3.7.0
     with_conf: true
-  pillow:
   pytables:
-  scorec:
-  sphinx:
-  #superlu:
-  sympy:
-  tetgen:
-  triangle:
+  tetgen: #3D simplex mesh generator
+  triangle: #2D simplex mesh generator
   memory_profiler:
-  ipdb:
-  pip:
-  pexpect:
-  doxygen:
-  netcdf4:
-  netcdf4cpp:
-  python-netcdf4:
-  h5py:
-  ode:
-  openblas:
-  jupyter:
-  functools:
-    use: host-functools
-  yaml:
-  pytest:
-  pytest-xdist:
   boost:
     toolset: darwin
+    address_model: 64
+    build_with: |
+      python
+  scipy:
+  h5py:
+  pip:
+  chrono:
+  pytest:
+  pytest-xdist:
+  pytest-cov:
+  pybind11:
+  gmsh: #used for mesh generation
+  scorec: #used for MeshAdapt
+  matplotlib: # used in testing suite 
+  pcs_api: #personal cloud storage api
+  #pyzmq:
+  #scandir:
+  #
+  ## Optional Packages
+  #buildbot-worker:
+  #doxygen: #for building documentation
+  #sphinx: #for building website
+  #sphinx-bootstrap-theme:
+
+  #clawpack:
+  #pydap:
+  #julia:
+  #pyjulia:
+  #jasper: 
+  #grib_api:
+  #cgal: computational geometric library
+  #pyproj:
+  #pygrib:
+  #rdp: #remote desktop package
+  #vapory:
+  #tornado:
+  #ipython:
+  #terminado:
+  #geojson:
+  #shapely:
+  #matlab:
+  #  use: host-matlab
+  #ipdb:
+  #jupyterlab:
+  #jupyter:
+  #ipyparallel:
+  backports-abc:
+  backports-shutil-get-terminal-size:
+  configparser:
+  #rtree:
+  #ipython-d3plot:
+  #ipython-gridwidget:
+  #jupyter-pip:
+  #leafletwidget:
+  #ipywidgets:
+  #ipyleaflet:
+  #pythreejs:
+  #proteus:
+  #sympy: #symbolic math library
+  #ode: #library which has ode solvers
+  #pygments:
+  #pillow: #python imaging library
+  #launcher:
+  #netcdf4:
+  #netcdf4f:
+  #python-netcdf4:
+  #netcdf4cpp:
+  #pexpect:
+
+
+
+

--- a/examples/proteus.darwin.yaml
+++ b/examples/proteus.darwin.yaml
@@ -59,7 +59,7 @@ packages:
     address_model: 64
     build_with: |
       python
-#  scipy:
+  scipy:
   h5py:
   pip:
   chrono:

--- a/examples/proteus.darwin.yaml
+++ b/examples/proteus.darwin.yaml
@@ -5,6 +5,7 @@
 # at the YAML files in the top-level directory and choose
 # the most *specific* file that matches your environment.
 
+
 extends:
 - file: homebrew.yaml
 
@@ -13,11 +14,12 @@ extends:
 # require installed.  <#> will ensure that all packages
 # and their dependencies are installed when you build this
 # profile.
-
 packages:
+  launcher:
+  future:
   recordtype:
   cmake:
-  openjpeg: #dependency of chrono
+  openjpeg: #for chronos
     version: '2.1'
   openssl:
   python:
@@ -34,31 +36,25 @@ packages:
     use: host-mpi
   mpi4py:
   nose:
-  coverage:
   hdf5:
   petsc:
-    version: 3.7.6
-    fortran: false
+    version: 3.10.2
     openblas: true
+    fortran: true
     build_with: |
       parmetis, cmake, blas
     download: |
-      superlu, superlu_dist, hypre, blacs
+      superlu, superlu_dist, hypre, blacs, scalapack, mumps
     coptflags: -O2
     link: shared
     debug: false
   petsc4py:
-    version: 3.7.0
+    version: 3.10.0
     with_conf: true
   pytables:
-  tetgen: #3D simplex mesh generator
-  triangle: #2D simplex mesh generator
+  tetgen:
+  triangle:
   memory_profiler:
-  boost:
-    toolset: darwin
-    address_model: 64
-    build_with: |
-      python
   scipy:
   h5py:
   pip:
@@ -68,63 +64,6 @@ packages:
   pytest-cov:
   pybind11:
   gmsh: #used for mesh generation
-  scorec: #used for MeshAdapt
-  matplotlib: # used in testing suite 
-  pcs_api: #personal cloud storage api
-  #pyzmq:
-  #scandir:
-  #
-  ## Optional Packages
-  #buildbot-worker:
-  #doxygen: #for building documentation
-  #sphinx: #for building website
-  #sphinx-bootstrap-theme:
-
-  #clawpack:
-  #pydap:
-  #julia:
-  #pyjulia:
-  #jasper: 
-  #grib_api:
-  #cgal: computational geometric library
-  #pyproj:
-  #pygrib:
-  #rdp: #remote desktop package
-  #vapory:
-  #tornado:
-  #ipython:
-  #terminado:
-  #geojson:
-  #shapely:
-  #matlab:
-  #  use: host-matlab
-  #ipdb:
-  #jupyterlab:
-  #jupyter:
-  #ipyparallel:
-  backports-abc:
-  backports-shutil-get-terminal-size:
-  configparser:
-  #rtree:
-  #ipython-d3plot:
-  #ipython-gridwidget:
-  #jupyter-pip:
-  #leafletwidget:
-  #ipywidgets:
-  #ipyleaflet:
-  #pythreejs:
-  #proteus:
-  #sympy: #symbolic math library
-  #ode: #library which has ode solvers
-  #pygments:
-  #pillow: #python imaging library
-  #launcher:
-  #netcdf4:
-  #netcdf4f:
-  #python-netcdf4:
-  #netcdf4cpp:
-  #pexpect:
-
-
-
+  zoltan:
+  scorec:
 

--- a/pkgs/chrono/chrono.yaml
+++ b/pkgs/chrono/chrono.yaml
@@ -1,53 +1,54 @@
 extends: [cmake_package]
 
 sources:
-- key: tar.gz:fewerd5wmhfc6evvlgnjineosbh6gyaz
-  url: https://github.com/projectchrono/chrono/archive/3.0.0.tar.gz
+- key: tar.gz:jdigwflegxlvjgspkxbtppl5kbncbobw
+  url: https://github.com/projectchrono/chrono/archive/f21f02bd274682883269819d1c274e7c834308c3.tar.gz
 
 defaults:
   relocatable: false
 
 dependencies:
   build:
+    - pcre
     - bzip2
     - python
     - zlib
-    - openjpeg
-    - png
     - swig
-    - blaze
-    - boost
-    - libjpeg
 
 build_stages:
-- name: cmakelists-patch
-  before: configure
-  files:
-    - lib64.patch
-  handler: bash
-  bash: |
-    patch -up1 < _hashdist/lib64.patch
-
 - name: configure
   extra:
+    - '-DBUILD_DEMOS:BOOL=OFF'
+    - '-DENABLE_MODULE_CASCADE:BOOL=OFF'
     - '-DENABLE_UNIT_CASCADE:BOOL=ON'
-    - '-DENABLE_MODULE_FEA:BOOL=ON'
     - '-DENABLE_MODULE_IRRLICHT:BOOL=OFF'
     - '-DENABLE_MODULE_POSTPROCESS:BOOL=ON'
     - '-DENABLE_MODULE_VEHICLE:BOOL=ON'
     - '-DENABLE_MODULE_FSI:BOOL=ON'
     - '-DENABLE_OPENMP:BOOL=ON'
-    - '-DENABLE_MODULE_PYTHON:BOOL=OFF'
+    - '-DENABLE_MODULE_PYTHON:BOOL=ON'
     - '-DENABLE_MODULE_COSIMULATION:BOOL=OFF'
     - '-DENABLE_MODULE_MATLAB:BOOL=OFF'
     - '-DENABLE_MODULE_MKL:BOOL=OFF'
     - '-DENABLE_MODULE_PARALLEL:BOOL=OFF'
     - '-DENABLE_MODULE_OPENGL:BOOL=OFF'
     - '-DENABLE_MODULE_OGRE:BOOL=OFF'
-    - '-DCMAKE_BUILD_TYPE:STRING=Debug'
-    - '-DBLAZE_DIR:PATH=${BLAZE_DIR}'
-    - '-DBOOST_DIR:PATH=${BOOST_DIR}/include'
+    - '-DCMAKE_BUILD_TYPE:STRING=Release'
     - '-DPYTHON_EXECUTABLE:PATH=${PYTHON}'
     - '-DPYTHON_INCLUDE_DIR:PATH=${PYTHON_DIR}/include/python2.7'
-    - '-DPYTHON_LIBRARY:PATH=${PYTHON_DIR}/lib/libpython2.7.so'
-    - '-DUSE_PARALLEL_SIMD:BOOL=ON'
+    - '-DPYTHON_LIBRARY:PATH=${PYTHON_DIR}/lib/libpython2.7.dylib'
+    - '-DSWIG_DIR:PATH=${SWIG_DIR}'
+
+- name: create_symlinks
+  after: install
+  when: platform == 'linux'
+  handler: bash
+  bash: |
+    cd ${ARTIFACT} && \
+    mkdir -p ${ARTIFACT}/lib/python{{pyver}}/site-packages && \
+    cp -r ${ARTIFACT}/share/chrono/python/* ${ARTIFACT}/lib/python{{pyver}}/site-packages
+
+profile_links:
+  - name: python_packages
+    link: 'lib/python{{pyver}}/site-packages/*'
+    dirs: true

--- a/pkgs/cython.yaml
+++ b/pkgs/cython.yaml
@@ -5,5 +5,12 @@ dependencies:
   run: []
 
 sources:
- - key: tar.gz:6fa5d6ocpid3lkj7pxcthfdsaz7c24ka
-   url: https://pypi.python.org/packages/b7/67/7e2a817f9e9c773ee3995c1e15204f5d01c8da71882016cac10342ef031b/Cython-0.25.2.tar.gz
+- key: tar.gz:gwrmrrpfhxxa6x6laj3hhtrr73ivpk7t
+  url: https://github.com/cython/cython/archive/0.29.6.tar.gz
+
+  #sources:
+  #- key: tar.gz:wzcxkja7mt3oyac2jvatom47wc5f4flo
+  #url: https://files.pythonhosted.org/packages/21/89/ca320e5b45d381ae0df74c4b5694f1471c1b2453c5eb4bac3449f5970481/Cython-0.28.5.tar.gz
+#sources:
+# - key: tar.gz:6fa5d6ocpid3lkj7pxcthfdsaz7c24ka
+#   url: https://pypi.python.org/packages/b7/67/7e2a817f9e9c773ee3995c1e15204f5d01c8da71882016cac10342ef031b/Cython-0.25.2.tar.gz

--- a/pkgs/gdbm.yaml
+++ b/pkgs/gdbm.yaml
@@ -4,5 +4,5 @@ defaults:
   relocatable: false
 
 sources:
-- key: tar.gz:rwis6rhqlufrljff3fvhn6cs5ec5aun3
-  url: http://ftp.heanet.ie/mirrors/gnu/gdbm/gdbm-1.11.tar.gz
+- key: tar.gz:zxhp6ah74akesw7nhlwxdr4rbkuix4ut
+  url: ftp://ftp.gnu.org/gnu/gdbm/gdbm-1.14.1.tar.gz

--- a/pkgs/gmsh.yaml
+++ b/pkgs/gmsh.yaml
@@ -1,21 +1,34 @@
 extends: [cmake_package]
 
 sources:
-- key: tar.gz:ydm74ehv6znhwwrwjt43tqya6qxln4wc
-  url: http://gmsh.info/src/gmsh-3.0.2-source.tgz
+- key: tar.gz:6pezgqebkolbxuf325relarrvpsqv2vl
+  url: http://gmsh.info/src/gmsh-4.0.2-source.tgz
 
 defaults:
   relocatable: false
 
 dependencies:
-  build: [swig, python, numpy, mpi, petsc, petsc4py, tetgen, lapack, blas, parmetis, hdf5]
-  run: [swig, python, numpy, mpi, petsc, petsc4py, tetgen, lapack, blas, parmetis, hdf5]
+  build: [swig, pcre, python, numpy, mpi, petsc, petsc4py, tetgen, lapack, blas, parmetis, hdf5]
+  run: [swig, pcre, python, numpy, mpi, petsc, petsc4py, tetgen, lapack, blas, parmetis, hdf5]
 
 build_stages:
 - name: configure
   extra:
-    - '-DENABLE_PETSC:BOOL=ON'
-    - '-DENABLE_PETSC4PY:BOOL=ON'
-    - '-DENABLE_FLTK:BOOL=OFF'
+    - '-DCMAKE_CXX_COMPILER:FILEPATH=${MPICXX}'
+    - '-DCMAKE_C_COMPILER:FILEPATH=${MPICC}'  
+    - '-DENABLE_FLTK:BOOL=ON'
     - '-DENABLE_BUILD_SHARED:BOOL=ON'
     - '-DENABLE_WRAP_PYTHON:BOOL=ON'
+    - '-DBLAS_LAPACK_LIBRARIES:STRING="${LAPACK_LDFLAGS};${BLAS_LDFLAGS}"'
+
+- when: machine == 'CrayXE6' or machine == 'CrayXC30' or machine == 'CrayXC40'
+  name: configure
+  extra:
+    - '-DCMAKE_CXX_COMPILER:FILEPATH=${MPICXX}'
+    - '-DCMAKE_C_COMPILER:FILEPATH=${MPICC}'  
+    - '-DENABLE_FLTK:BOOL=OFF'
+    - '-DENABLE_PETSC:BOOL=OFF'
+    - '-DENABLE_BUILD_SHARED:BOOL=ON'
+    - '-DENABLE_WRAP_PYTHON:BOOL=ON'
+    - '-DBLAS_LAPACK_LIBRARIES:STRING="${LAPACK_LDFLAGS};${BLAS_LDFLAGS}"'
+    - '-DCMAKE_SKIP_INSTALL_RPATH:BOOL=ON'

--- a/pkgs/libtool.yaml
+++ b/pkgs/libtool.yaml
@@ -4,8 +4,8 @@ defaults:
   relocatable: false
 
 sources:
-- key: tar.gz:wog6isdcvgdsspgt3dp24hcatviuw3co
-  url: http://ftp.heanet.ie/mirrors/gnu/libtool/libtool-2.4.2.tar.gz
+- key: tar.gz:4o6u2xj5ajndnqq522xx5kayukx42tp4
+  url: https://ftp.gnu.org/gnu/libtool/libtool-2.4.6.tar.gz
 
 when_build_dependency:
 - prepend_path: PATH

--- a/pkgs/numpy/numpy.yaml
+++ b/pkgs/numpy/numpy.yaml
@@ -34,6 +34,29 @@ build_stages:
       export LAPACK=None
       export BLAS=None
 
+  - when: platform == 'Darwin'
+    name: create-site.cfg
+    before: install
+    handler: bash
+    bash: |
+      cat > site.cfg << EOF
+      [openblas]
+      libraries = openblas
+      library_dirs = ${OPENBLAS_DIR}/lib
+      include_dirs = ${OPENBLAS_DIR}/include
+      runtime_library_dirs = ${OPENBLAS_DIR}/include
+      EOF
+
+  - when: platform == 'Darwin'
+    name: set-LDFLAGS
+    before: install
+    handler: bash
+    bash: |
+      export LDFLAGS="$(${PYTHON_DIR}/bin/python-config --ldflags)"
+      #export ATLAS=None
+      export LAPACK=None
+      export BLAS=None
+
   - when: machine == 'SGIICEX'
     name: create-site.cfg
     after: prologue

--- a/pkgs/openssl/openssl.yaml
+++ b/pkgs/openssl/openssl.yaml
@@ -44,7 +44,7 @@ build_stages:
   mode: replace
   bash: |
     #./config --prefix=$ARTIFACT shared zlib-dynamic -I$ZLIB_DIR/include -Wl,-rpath=$ARTIFACT/lib -Wl,-rpath=$ZLIB_DIR/lib
-    ./Configure --prefix=$ARTIFACT shared zlib-dynamic -I$ZLIB_DIR/include darwin64-x86_64-cc enable-ec_nistp-64_gcc_128
+    ./Configure --prefix=$ARTIFACT shared zlib-dynamic -I$ZLIB_DIR/include darwin64-x86_64-cc enable-ec_nistp_64_gcc_128
 
 - when: platform == 'linux'
   name: fix_rpath

--- a/pkgs/perl.yaml
+++ b/pkgs/perl.yaml
@@ -4,7 +4,7 @@ defaults:
   relocatable: false
 
 dependencies:
-  build: [berkeleydb-5, gdbm, {{build_with}}]
+  build: [berkeleydb-5, {{build_with}}]
 
 sources:
 - key: tar.gz:j2gcrllozsezal44wltw6kavxmnifb66

--- a/pkgs/petsc/petsc.yaml
+++ b/pkgs/petsc/petsc.yaml
@@ -2,10 +2,18 @@ extends: [autotools_package]
 dependencies:
   build: [blas, mpi, python, cmake, {{build_with}}]
 
+when version == '3.10.2':
+  sources:
+  - key: tar.gz:5kjlowzwrngicdt5zqsxcibknhirohj3
+    url: https://bitbucket.org/petsc/petsc/get/v3.10.2.tar.gz
 when version == 'master':
   sources:
   - key: git:8c405a35e3463db34467c44b5b94e7b81d895f6d
     url: https://bitbucket.org/petsc/petsc
+when version == '3.8.4':
+  sources:
+  - key: tar.gz:jnir6togvymxfogd2jlhhpblcjrhoxpx
+    url: http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-lite-3.8.4.tar.gz
 when version == '3.7.6':
   sources:
   - key: tar.gz:wb7xwtsx25pzqj4hxwawt55y326vv3re
@@ -52,6 +60,7 @@ build_stages:
   link: {{link}}
   debug: {{debug}}
   download: [{{download}}]
+  use_downloaded: [{{use_downloaded}}]
 
 # PETSc 3.5 does not allow the use of the -j option to make
 -  name: make

--- a/pkgs/petsc4py/petsc4py.yaml
+++ b/pkgs/petsc4py/petsc4py.yaml
@@ -49,9 +49,17 @@ build_stages:
 #      PATH=$PATH:$PETSC_DIR/bin \
 #      $PYTHON runtests.py)
 
+when version == '3.10.0':
+  sources:
+  - key: tar.gz:on7hqewmyvfr4dlorxsl3tminsgofbys
+    url: https://bitbucket.org/petsc/petsc4py/get/3.10.0.tar.gz
 when version == 'master': #note, update commits on petsc and petsc4py to use master
   - key: git:8c9fc3a08c95098a208468fe9546fa5952638d12
     url: https://bitbucket.org/petsc/petsc4py
+when version == '3.8.1':
+  sources:
+  - key: tar.gz:263symzx3xcwamottufvfv7srnq6zra3
+    url: https://bitbucket.org/petsc/petsc4py/downloads/petsc4py-3.8.1.tar.gz
 when version == '3.7.0':
   sources:
   - key: tar.gz:4h62pjucmtb6ziqbj4st57spgbx2shln

--- a/pkgs/pytables/pytables.yaml
+++ b/pkgs/pytables/pytables.yaml
@@ -20,4 +20,4 @@ build_stages:
        --single-version-externally-managed \
        --lflags="-Wl,-rpath,${HDF5_DIR}/lib -L${HDF5_DIR}/lib -lhdf5 \
        -Wl,-rpath,${ZLIB_DIR}/lib -L${ZLIB_DIR} -lz \
-       -Wl,-rpath,${SZIP_DIR}/lib -L${SZIP_DIR}/lib -lszip"
+       -Wl,-rpath,${SZIP_DIR}/lib -L${SZIP_DIR}/lib -lszip-shared"

--- a/pkgs/python/python.yaml
+++ b/pkgs/python/python.yaml
@@ -27,7 +27,7 @@ when pyver == '3.6':
 
 
 dependencies:
-  build: [zlib, bzip2, sqlite, openssl, launcher, ncurses, readline, gdbm, {{build_with}}]
+  build: [zlib, bzip2, sqlite, openssl, launcher, ncurses, readline, {{build_with}}]
   run: []
 
 defaults:

--- a/pkgs/scipy/scipy.yaml
+++ b/pkgs/scipy/scipy.yaml
@@ -24,6 +24,19 @@ build_stages:
       echo "include_dirs = ${OPENBLAS_DIR}/lib" >> site.cfg
       echo "runtime_library_dirs = ${OPENBLAS_DIR}/lib" >> site.cfg
 
+  - when: platform == 'Darwin'
+    name: set-lapack-paths
+    after: libflags
+    before: install
+    handler: bash
+    bash: |
+      export LDFLAGS="-undefined dynamic_lookup $(${PYTHON_DIR}/bin/python-config --ldflags)"
+      echo "[openblas]" >> site.cfg
+      echo "libraries = openblas" >> site.cfg
+      echo "library_dirs = ${OPENBLAS_DIR}/lib" >> site.cfg
+      echo "include_dirs = ${OPENBLAS_DIR}/lib" >> site.cfg
+      echo "runtime_library_dirs = ${OPENBLAS_DIR}/lib" >> site.cfg
+
   - name: install
     after: setup_dirs
     mode: replace

--- a/pkgs/scipy/scipy.yaml
+++ b/pkgs/scipy/scipy.yaml
@@ -1,14 +1,12 @@
-when platform != 'linux':
-  extends: [distutils_package]
-when platform == 'linux':
-  extends: [setuptools_package, libflags]
+extends: [setuptools_package, libflags]
+
 dependencies:
-  build: [blas, lapack, numpy]
+  build: [blas, lapack, numpy, cython]
   run: [blas, lapack, numpy]
 
 sources:
-- key: tar.gz:q7vb6ena5hwarqte3rsfkhkqd6rqokeu
-  url: https://github.com/scipy/scipy/releases/download/v1.0.0/scipy-1.0.0.tar.gz
+- key: tar.gz:q444m6cc5wnbynggfvwmuyyb2cw6idkq
+  url: https://github.com/scipy/scipy/releases/download/v1.0.1/scipy-1.0.1.tar.gz
 
 build_stages:
   - when: platform == 'linux'
@@ -17,8 +15,25 @@ build_stages:
     before: install
     handler: bash
     bash: |
-      export LDFLAGS="$LDFLAGS -shared $LAPACK_LDFLAGS $BLAS_LDFLAGS"
-      export ATLAS=None
-      export OPENBLAS=$OPENBLAS_DIR
-      export LAPACK=$LAPACK_LDFLAGS
-      export BLAS=$BLAS_LDFLAGS
+      export LDFLAGS="-shared -Wl,-rpath=${PYTHON_DIR}/lib $(${PYTHON_DIR}/bin/python-config --ldflags)"
+      echo "[ALL]" > site.cfg
+      echo "extra_link_args = -shared" >> site.cfg
+      echo "[openblas]" >> site.cfg
+      echo "libraries = openblas" >> site.cfg
+      echo "library_dirs = ${OPENBLAS_DIR}/lib" >> site.cfg
+      echo "include_dirs = ${OPENBLAS_DIR}/lib" >> site.cfg
+      echo "runtime_library_dirs = ${OPENBLAS_DIR}/lib" >> site.cfg
+
+  - name: install
+    after: setup_dirs
+    mode: replace
+    handler: bash
+    bash: |
+      ${PYTHON} -c 'import setuptools; __file__="setup.py"; exec(open(__file__).read())' \
+         ${SETUPTOOLS_PACKAGE_EXTRA_OPTIONS} \
+         build
+      ${PYTHON} -c 'import setuptools; __file__="setup.py"; exec(open(__file__).read())' \
+         ${SETUPTOOLS_PACKAGE_EXTRA_OPTIONS} \
+         install \
+         --prefix=. --root=${ARTIFACT} \
+         --single-version-externally-managed

--- a/pkgs/scipy/scipy.yaml
+++ b/pkgs/scipy/scipy.yaml
@@ -4,26 +4,12 @@ dependencies:
   build: [blas, lapack, numpy, cython]
   run: [blas, lapack, numpy]
 
+  
 sources:
-- key: tar.gz:q444m6cc5wnbynggfvwmuyyb2cw6idkq
-  url: https://github.com/scipy/scipy/releases/download/v1.0.1/scipy-1.0.1.tar.gz
+- key: tar.gz:4cc5dov4wqm3xzmof2afvrqzetnmjssf
+  url: https://github.com/scipy/scipy/releases/download/v1.2.1/scipy-1.2.1.tar.gz
 
 build_stages:
-  - when: platform == 'linux'
-    name: set-lapack-paths
-    after: libflags
-    before: install
-    handler: bash
-    bash: |
-      export LDFLAGS="-shared -Wl,-rpath=${PYTHON_DIR}/lib $(${PYTHON_DIR}/bin/python-config --ldflags)"
-      echo "[ALL]" > site.cfg
-      echo "extra_link_args = -shared" >> site.cfg
-      echo "[openblas]" >> site.cfg
-      echo "libraries = openblas" >> site.cfg
-      echo "library_dirs = ${OPENBLAS_DIR}/lib" >> site.cfg
-      echo "include_dirs = ${OPENBLAS_DIR}/lib" >> site.cfg
-      echo "runtime_library_dirs = ${OPENBLAS_DIR}/lib" >> site.cfg
-
   - when: platform == 'Darwin'
     name: set-lapack-paths
     after: libflags
@@ -36,7 +22,6 @@ build_stages:
       echo "library_dirs = ${OPENBLAS_DIR}/lib" >> site.cfg
       echo "include_dirs = ${OPENBLAS_DIR}/lib" >> site.cfg
       echo "runtime_library_dirs = ${OPENBLAS_DIR}/lib" >> site.cfg
-
   - name: install
     after: setup_dirs
     mode: replace

--- a/pkgs/scorec/scorec.yaml
+++ b/pkgs/scorec/scorec.yaml
@@ -22,14 +22,14 @@ build_stages:
     mkdir -p _build
     cd _build
 
-- when: platform == 'Darwin'
-  name: turn_off_werror
-  files:
-    - werror.patch
-  before: setup_builddir
-  handler: bash
-  bash: |
-    patch -p1 < _hashdist/werror.patch
+#- when: platform == 'Darwin'
+#  name: turn_off_werror
+#  files:
+#    - werror.patch
+#  before: setup_builddir
+#  handler: bash
+#  bash: |
+#    patch -p1 < _hashdist/werror.patch
 
 - name: configure
   debug: true

--- a/pkgs/scorec/scorec.yaml
+++ b/pkgs/scorec/scorec.yaml
@@ -18,6 +18,15 @@ build_stages:
     mkdir -p _build
     cd _build
 
+- when: platform == 'Darwin'
+  name: turn_off_werror
+  files:
+    - werror.patch
+  before: setup_builddir
+  handler: bash
+  bash: |
+    patch -p1 < _hashdist/werror.patch
+
 - name: configure
   debug: true
   extra: [

--- a/pkgs/scorec/werror.patch
+++ b/pkgs/scorec/werror.patch
@@ -1,0 +1,36 @@
+diff --git a/cmake/bob.cmake b/cmake/bob.cmake
+index 63780b94..9e6d5c34 100644
+--- a/cmake/bob.cmake
++++ b/cmake/bob.cmake
+@@ -55,14 +55,14 @@ function(bob_begin_cxx_flags)
+   endif()
+   if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+     if (${PROJECT_NAME}_CXX_WARNINGS)
+-      set(FLAGS "${FLAGS} -Werror -Weverything")
++      set(FLAGS "${FLAGS}")
+       set(FLAGS "${FLAGS} -Wno-padded")
+       set(FLAGS "${FLAGS} -Wno-float-equal")
+       set(FLAGS "${FLAGS} -Wno-weak-template-vtables")
+     endif()
+   elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
+     if (${PROJECT_NAME}_CXX_WARNINGS)
+-      set(FLAGS "${FLAGS} -Werror -Wall -Wextra")
++      set(FLAGS "${FLAGS}")
+     endif()
+   elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "Intel")
+   else()
+diff --git a/mpich3-gcc4.9.2-config.sh b/mpich3-gcc4.9.2-config.sh
+index c1edb6af..785e2852 100755
+--- a/mpich3-gcc4.9.2-config.sh
++++ b/mpich3-gcc4.9.2-config.sh
+@@ -5,8 +5,8 @@ PREFIX=/lore/seol/mpich3-gcc4.9.2-install
+ cmake .. \
+   -DCMAKE_C_COMPILER="/usr/local/mpich3/latest/bin/mpicc" \
+   -DCMAKE_CXX_COMPILER="/usr/local/mpich3/latest/bin/mpicxx" \
+-  -DCMAKE_C_FLAGS=" -g -O2 -Wall -Wextra -Werror" \
+-  -DCMAKE_CXX_FLAGS=" -g -O2 -Wall -Wextra -Werror" \
++  -DCMAKE_C_FLAGS=" -g -O2 -Wall -Wextra " \
++  -DCMAKE_CXX_FLAGS=" -g -O2 -Wall -Wextra " \
+   -DENABLE_ZOLTAN=ON \
+   -DZOLTAN_INCLUDE_DIR="$ZOLTAN_DIR/include" \
+   -DZOLTAN_LIBRARY="$ZOLTAN_DIR/lib/libzoltan.a" \

--- a/pkgs/szip.yaml
+++ b/pkgs/szip.yaml
@@ -1,8 +1,8 @@
 extends: [cmake_package]
 
 sources:
-- url: https://support.hdfgroup.org/ftp/lib-external/szip/2.1/src/szip-2.1.tar.gz
-  key: tar.gz:valnsxkwmlucpfrfvpn6u7iomikx27i7
+- key: tar.gz:ehxjlc2pfvf6fsokx6s6dkkio4cdmcoo
+  url: https://support.hdfgroup.org/ftp/lib-external/szip/2.1.1/src/szip-2.1.1.tar.gz
 
 build_stages:
 - name: configure


### PR DESCRIPTION
Compared to the latest `proteus.linux2.yaml`, I am trying to update `proteus.darwin.yaml` and several other packages `when: platform == 'Darwin'`. The main differences are:

- petsc: use Fortran because of scalapack
- Chrono: use the ending `.dylib`
- openssl: use `_64` Thanks to @ejtovar 

One has to install all c header files on Mac os by running the command `open /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg` in a terminal. 

Here I am using `gcc` and `mpich` installed by homebrew. 
 