### PR TITLE
SCOREC: update commit to include lionPrint

### DIFF
--- a/pkgs/scorec.yaml
+++ b/pkgs/scorec.yaml
@@ -7,8 +7,8 @@ dependencies:
 #  - url: https://github.com/scorec/core.git
 #    key: git:fc94c3d4b013d7535e43549577b2c5f619d43d4b
 sources:
-- key: zip:ttofytsvsn7wiy5mw3utbdbmobbw7zr7
-  url: https://github.com/SCOREC/core/archive/fc94c3d4b013d7535e43549577b2c5f619d43d4b.zip
+- key: zip:f2lso4iu2raobfwovh43h6z556b6vcni
+  url: https://github.com/SCOREC/core/archive/dfe08cd01552acf4b758bf942dade27e4ea46f22.zip
 
 defaults:
   relocatable: true


### PR DESCRIPTION
Need to update the scorec package to get the lionPrint.h and verbose statements in MeshAdapt related function calls.