### PR TITLE
Add xtensor to the stack

### DIFF
--- a/examples/proteus.linux.yaml
+++ b/examples/proteus.linux.yaml
@@ -70,11 +70,8 @@ packages:
   gmsh: #used for mesh generation
   zoltan:
   scorec:
-  superlu:
-  superlu_dist:
   xtensor:
   xtensor-python:
-  #scorec:
   #matplotlib: # used in testing suite 
   #pcs_api: #personal cloud storage api
   #pyzmq:

--- a/examples/proteus.linux.yaml
+++ b/examples/proteus.linux.yaml
@@ -33,10 +33,8 @@ packages:
       bzip2, sqlite, openssl
   blas:
     use: openblas
-    #use: host-blas
   lapack:
     use: openblas-lapack
-    #use: host-lapack
   daetk:
   mpi:
     use: mpich
@@ -70,6 +68,8 @@ packages:
   pytest-cov:
   pybind11:
   gmsh: #used for mesh generation
+  zoltan:
+  scorec:
   superlu:
   superlu_dist:
   xtensor:

--- a/examples/proteus.linux.yaml
+++ b/examples/proteus.linux.yaml
@@ -11,7 +11,7 @@ extends:
 parameters:
   pyver: '3.7'
   python_site_packages_rel: 'lib/python3.7/site-packages'
-  python_host_packages: '/usr/lib/python3.7/dist-packages'
+  python_host_packages: '/usr/lib/python3.7/site-packages'
 
 # The packages list specifies all the packages that you
 # require installed.  <#> will ensure that all packages
@@ -33,8 +33,10 @@ packages:
       bzip2, sqlite, openssl
   blas:
     use: openblas
+    #use: host-blas
   lapack:
     use: openblas-lapack
+    #use: host-lapack
   daetk:
   mpi:
     use: mpich
@@ -68,8 +70,11 @@ packages:
   pytest-cov:
   pybind11:
   gmsh: #used for mesh generation
-  zoltan:
-  scorec:
+  superlu:
+  superlu_dist:
+  xtensor:
+  xtensor-python:
+  #scorec:
   #matplotlib: # used in testing suite 
   #pcs_api: #personal cloud storage api
   #pyzmq:

--- a/pkgs/pybind11.yaml
+++ b/pkgs/pybind11.yaml
@@ -5,5 +5,5 @@ dependencies:
   run: []
 
 sources:
- - key: tar.gz:vfvjet5onytsd357et2hkyjij7i6uc3f
-   url: https://pypi.python.org/packages/c9/f7/fc9c44bf088d942c71b04646891034036a63e5bd00daff1c9a377e0f5a9f/pybind11-2.2.1.tar.gz
+ - key: tar.gz:d3wvppdimmmq4nldokips6razaop4tmq
+   url: https://github.com/pybind/pybind11/archive/v2.4.3.tar.gz

--- a/pkgs/pybind11_cmake.yaml
+++ b/pkgs/pybind11_cmake.yaml
@@ -1,12 +1,12 @@
 extends: [cmake_package]
 
 dependencies:
-  build: [xtensor, xtl, mpi, pybind11_cmake]
-  run: [xtensor, xtl, mpi, pybind11_cmake]
+  build: [mpi]
+  run: [mpi]
 
 sources:
-  - key: tar.gz:4lrfc4q3tl6w6urj73cyxzizc6jalogv
-    url: https://github.com/QuantStack/xtensor-python/archive/0.24.1.tar.gz
+ - key: tar.gz:d3wvppdimmmq4nldokips6razaop4tmq
+   url: https://github.com/pybind/pybind11/archive/v2.4.3.tar.gz
 
 defaults:
   relocatable: true
@@ -22,6 +22,5 @@ build_stages:
 - name: configure
   debug: true
   extra: [
-  '-DCMAKE_C_COMPILER:STRING=${MPICC}',
   '-DCMAKE_CXX_COMPILER:STRING=${MPICXX}',
   ]

--- a/pkgs/pybind11_cmake.yaml
+++ b/pkgs/pybind11_cmake.yaml
@@ -1,8 +1,8 @@
 extends: [cmake_package]
 
 dependencies:
-  build: [mpi]
-  run: [mpi]
+  build: [mpi, python, pytest]
+  run: [mpi, python, pytest]
 
 sources:
  - key: tar.gz:d3wvppdimmmq4nldokips6razaop4tmq
@@ -23,4 +23,6 @@ build_stages:
   debug: true
   extra: [
   '-DCMAKE_CXX_COMPILER:STRING=${MPICXX}',
+  '-DPYBIND11_TEST:BOOL=OFF',
   ]
+

--- a/pkgs/xtensor-python.yaml
+++ b/pkgs/xtensor-python.yaml
@@ -1,0 +1,28 @@
+extends: [cmake_package]
+
+dependencies:
+  build: [xtensor, xtl, mpi, pybind11]
+  run: [xtensor, xtl, mpi, pybind11]
+
+sources:
+  - key: tar.gz:4lrfc4q3tl6w6urj73cyxzizc6jalogv
+    url: https://github.com/QuantStack/xtensor-python/archive/0.24.1.tar.gz
+
+defaults:
+  relocatable: true
+
+build_stages:
+- name: setup_builddir
+  after: prologue
+  handler: bash
+  bash: |
+    mkdir -p _build
+    cd _build
+
+- name: configure
+  debug: true
+  extra: [
+  '-DCMAKE_C_COMPILER:STRING=${MPICC}',
+  '-DCMAKE_CXX_COMPILER:STRING=${MPICXX}',
+  # '-DXTENSOR_USE_XSIMD:bool=0',
+  ]

--- a/pkgs/xtensor.yaml
+++ b/pkgs/xtensor.yaml
@@ -1,0 +1,28 @@
+extends: [cmake_package]
+
+dependencies:
+  build: [xtl, mpi]
+  run: [xtl, mpi]
+
+sources:
+  - key: tar.gz:umsjbpeeth2z7drqykeoc6h7ihevchhu
+    url: https://github.com/xtensor-stack/xtensor/archive/0.21.2.tar.gz
+
+defaults:
+  relocatable: true
+
+build_stages:
+- name: setup_builddir
+  after: prologue
+  handler: bash
+  bash: |
+    mkdir -p _build
+    cd _build
+
+- name: configure
+  debug: true
+  extra: [
+  '-DCMAKE_C_COMPILER:STRING=${MPICC}',
+  '-DCMAKE_CXX_COMPILER:STRING=${MPICXX}',
+  # '-DXTENSOR_USE_XSIMD:INT=0',
+  ]

--- a/pkgs/xtensor.yaml
+++ b/pkgs/xtensor.yaml
@@ -5,8 +5,8 @@ dependencies:
   run: [xtl, mpi]
 
 sources:
-  - key: tar.gz:umsjbpeeth2z7drqykeoc6h7ihevchhu
-    url: https://github.com/xtensor-stack/xtensor/archive/0.21.2.tar.gz
+  - key: tar.gz:6y6clsx6us74e2hnwjxg6uaeukfc62e6
+    url: https://github.com/xtensor-stack/xtensor/archive/0.21.3.tar.gz
 
 defaults:
   relocatable: true

--- a/pkgs/xtl.yaml
+++ b/pkgs/xtl.yaml
@@ -1,0 +1,27 @@
+extends: [cmake_package]
+
+dependencies:
+  build: [mpi]
+  run: [mpi]
+
+sources:
+  - key: tar.gz:4pfwelppc5fxmvd4fhha2y5ocqd62gp4
+    url: https://github.com/QuantStack/xtl/archive/0.6.11.tar.gz
+
+defaults:
+  relocatable: true
+
+build_stages:
+- name: setup_builddir
+  after: prologue
+  handler: bash
+  bash: |
+    mkdir -p _build
+    cd _build
+
+- name: configure
+  debug: true
+  extra: [
+  '-DCMAKE_C_COMPILER:STRING=${MPICC}',
+  '-DCMAKE_CXX_COMPILER:STRING=${MPICXX}',
+  ]


### PR DESCRIPTION
This PR is to add xtensor to the stack and get rid of `get_xtensor.sh` in the Proteus repository

- [x] add xtl
- [x] add xtensor
- [x] add pybind11_cmake
- [x] add xtensor-python
- [x] check proteus install

@cekees @JohanMabille @zhang-alvin 