### PR TITLE
Xtensor fails on Travis-CI 

### DIFF
--- a/pkgs/xtensor-python.yaml
+++ b/pkgs/xtensor-python.yaml
@@ -1,7 +1,7 @@
 extends: [cmake_package]
 
 dependencies:
-  build: [xtensor, xtl, mpi, pybind11_cmake]
+  build: [xtensor, xtl, mpi, pybind11_cmake,numpy,python]
   run: [xtensor, xtl, mpi, pybind11_cmake]
 
 sources:
@@ -20,7 +20,7 @@ build_stages:
     cd _build
 
 - name: configure
-  debug: true
+  debug: false
   extra: [
   '-DCMAKE_C_COMPILER:STRING=${MPICC}',
   '-DCMAKE_CXX_COMPILER:STRING=${MPICXX}',


### PR DESCRIPTION
The xtensor-python package fails to build on Travis because the numpy module and python interpreter are not specified at compile time. 

```
[[33mxtensor-python[39;49;00m] CMake Error at cmake/FindNumPy.cmake:61 (message):
[[33mxtensor-python[39;49;00m]   NumPy import failure:
[[33mxtensor-python[39;49;00m] 
[[33mxtensor-python[39;49;00m]   Traceback (most recent call last):
[[33mxtensor-python[39;49;00m] 
[[33mxtensor-python[39;49;00m]     File "/home/travis/hashdist_bld/numpy/zrlvczrgmu4c/lib/python3.7/site-packages/numpy/core/__init__.py", line 40, in <module>
[[33mxtensor-python[39;49;00m]       from . import multiarray
[[33mxtensor-python[39;49;00m]     File "/home/travis/hashdist_bld/numpy/zrlvczrgmu4c/lib/python3.7/site-packages/numpy/core/multiarray.py", line 13, in <module>
[[33mxtensor-python[39;49;00m]       from . import overrides
[[33mxtensor-python[39;49;00m]     File "/home/travis/hashdist_bld/numpy/zrlvczrgmu4c/lib/python3.7/site-packages/numpy/core/overrides.py", line 6, in <module>
[[33mxtensor-python[39;49;00m]       from numpy.core._multiarray_umath import (
[[33mxtensor-python[39;49;00m] 
[[33mxtensor-python[39;49;00m]   ImportError: No module named 'numpy.core._multiarray_umath'
```

If the numpy package is specified as a dependency, but the python package is not, then CMake finds the host python leading to an error: 
```
[[33mxtensor-python[39;49;00m] -- Found PythonInterp: /usr/bin/python3.5 (found version "3.5.2") 
[[33mxtensor-python[39;49;00m] -- Found PythonLibs: /usr/lib/x86_64-linux-gnu/libpython3.5m.so
```

Locally, this can pass without specifying either package because there may be a functional pairing of numpy and python on the host machine.